### PR TITLE
chore(FE): eslint 설정 개행 문자열 예외 설정

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -37,7 +37,13 @@ module.exports = {
       2,
       { namedComponents: 'arrow-function' },
     ],
-    'prettier/prettier': ['error', { singleQuote: true }],
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true,
+        endOfLine: 'auto',
+      },
+    ],
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
## 1. 요약

- eslint 설정 개행 문자열 예외 설정
- eslintrc.js에 endOfLine: 'auto'  추가


## 2. 작업 내용
- prettier 설정이 eslint에 개행 문자열에 대한 설정이 지정되지 않아서 
  빌드시에 개행 문자에 대한 해당 에러가 발생함
![image](https://user-images.githubusercontent.com/11059706/169388432-d60c53c2-6c08-4dec-a911-eb61d01595d5.png)




---

PR 유형
어떤 종류에 PR입니까?

- [ ] Bugfix
- [ ] Feature
- [ ] Code 스타일 변경 (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build 관련 변경
- [X] CI 관련 변경
- [ ] Documentation 내용 변경




** 체크 표시는 - [X] 입니다.